### PR TITLE
Better metadata parse error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Python-Future 0.10.0 introduced the raise_with_traceback() funtion
+# See http://python-future.org/changelog.html#utility-functions-raise-and-exec
+future>=0.10.0

--- a/spankki.py
+++ b/spankki.py
@@ -84,6 +84,12 @@ def removeMetaData(s):
 
 
 #store statement metadata
+
+
+class MetadataParseError(ParseError):
+    problem_description = 'Cannot find statement metadata'
+
+
 def parseStatementMetadata(statement,path):
     #data example
     """
@@ -98,6 +104,8 @@ def parseStatementMetadata(statement,path):
     
     matchRow1 = re.compile(".*KAUSI\s+(?P<StDateStart>[\d\.]+)+\s-\s(?P<StDateEnd>[\d\.]+).*tapahtumista\.\s+(?P<StAccountIban>\w\w[\d\s]+)\s+(?P<StAccountBic>\w+)\s",flags=re.DOTALL)
     m1 = re.match(matchRow1,statement)
+    if not m1:
+        raise MetadataParseError(statement)
         
     #print m1.groupdict()
 

--- a/spankki.py
+++ b/spankki.py
@@ -8,6 +8,21 @@ import cleantransactions
 
 #regular expressions can be tested easily in http://regex101.com/#python by using following flags: ms
 
+
+class ParseError(Exception):
+    """"Base class for parse exceptions"""
+
+    def __init__(self, source_text):
+        self.source_text = source_text
+
+    def __str__(self):
+        if '\n' in self.source_text:
+            source = '{} lines of text'.format(len(self.source_text))
+        else:
+            source = repr(self.source_text)
+        return '{} in {}'.format(self.problem_description, source)
+
+
 #remove page breaks and other meta data
 def removeMetaData(s):
     """


### PR DESCRIPTION
If the metadata parser regex fails, the error message doesn't tell
- that it's the metadata parsing which caused the error
- which statement file the problem was in

This patch makes the error message more descriptive.
